### PR TITLE
Bump Chartist to 0.9.8

### DIFF
--- a/blueprints/ember-cli-chartist/index.js
+++ b/blueprints/ember-cli-chartist/index.js
@@ -9,6 +9,6 @@ module.exports = {
   },
 
   beforeInstall: function(options) {
-    return this.addBowerPackageToProject('chartist', '~0.9.1');
+    return this.addBowerPackageToProject('chartist', '~0.9.8');
   }
 };


### PR DESCRIPTION
This technically isn't required, but it keeps us current.